### PR TITLE
Change company name to use small "r", updated link

### DIFF
--- a/remote-access/access-over-Internet/README.md
+++ b/remote-access/access-over-Internet/README.md
@@ -10,7 +10,7 @@ One method is to set up port forwarding on your router. To do this, you must cha
 
 Rather than using port forwarding, there are a number of alternative third-party services available. These provide varying levels of functionality - see their websites for more details.
 
-- [Remote.it](https://www.remote.it)
+- [remote.it](https://remote.it/developers#raspberry-pi)
 - [Dataplicity](https://dataplicity.com)
 - [Yaler.net](https://yaler.net/)
 - [Losant](https://losant.com)


### PR DESCRIPTION
Link now points at "Getting Started for Raspberry Pi" page.